### PR TITLE
Added purdy icons and changed project link

### DIFF
--- a/Caf.Midden.Wasm/Shared/FilteredCatalogMetadataViewer.razor
+++ b/Caf.Midden.Wasm/Shared/FilteredCatalogMetadataViewer.razor
@@ -33,10 +33,13 @@
                     </Button>
                 </Extra>
                 <Body>
+                    <Icon Type="folder" />
                     <a href="catalog/zones/@metadata.Dataset.Zone">
                         @metadata.Dataset.Zone
-                    </a> /
-                    <a href="catalog/zones/@metadata.Dataset.Zone/projects/@metadata.Dataset.Project">
+                    </a>
+                    <Divider Type="DirectionVHType.Vertical" />
+                    <Icon Type="project" />
+                    <a href="catalog/projects/@metadata.Dataset.Project">
                         @metadata.Dataset.Project
                     </a>
 


### PR DESCRIPTION
Changes how project links work. They now links to catalog/projects/{ProjectName} instead of catalog/zones/{ZoneName}/projects/{ProjectName}. To better emphasize this change, the zone and projects are not represented as a path but instead as independent items.

Closes #80 